### PR TITLE
最低APIレベルを21から16に変更

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
     buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "com.example.t_robop.matomemo"
-        minSdkVersion 21
+        minSdkVersion 16
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
ロボPタブレットでも最低限起動するようになります